### PR TITLE
Fix #41 Parse JUnit output

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "morgan": "^1.9.1",
     "nodegit": "^0.24.0",
     "octonode": "^0.9.5",
+    "rimraf": "^2.6.3",
     "shelljs": "^0.8.3"
   },
   "devDependencies": {
@@ -32,6 +33,7 @@
     "@types/mongoose": "^5.3.12",
     "@types/morgan": "^1.7.35",
     "@types/nodegit": "^0.24.0",
+    "@types/rimraf": "^2.0.2",
     "@types/shelljs": "^0.8.2",
     "husky": "^1.3.1",
     "lint-staged": "^8.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,9 +48,6 @@ app.get('/', (req, res) => {
   res.json({ success: true });
 });
 
-const test = path.join(__dirname, '..');
-console.log(test);
-
 app.post('/ci', async (req, res) => {
   if (!process.env.GITHUB_TOKEN) {
     console.log(

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,12 @@ import { GithubStatus } from './status';
 import * as java from './java';
 import * as mongoose from 'mongoose';
 import to from 'await-to-js';
+import * as rimraf from 'rimraf';
 
 import Build from './models/build';
+
+import * as shell from 'shelljs';
+import * as path from 'path';
 
 mongoose
   .connect(process.env.MONGODB_URL, {
@@ -43,6 +47,9 @@ app.use(cors());
 app.get('/', (req, res) => {
   res.json({ success: true });
 });
+
+const test = path.join(__dirname, '..');
+console.log(test);
 
 app.post('/ci', async (req, res) => {
   if (!process.env.GITHUB_TOKEN) {
@@ -139,6 +146,11 @@ app.post('/ci', async (req, res) => {
   });
 
   const [saveError] = await to(build.save());
+
+  // Remove commitId directory when we are done
+  const rootDir = path.join(__dirname, '..');
+  shell.cd(rootDir);
+  rimraf.sync(directoryPath);
 
   if (saveError) {
     console.log(`Error when saving to database: ${saveError}`);

--- a/src/java.ts
+++ b/src/java.ts
@@ -26,9 +26,6 @@ const compileCode = async (path: string) => {
 };
 
 const testCode = async (path: string, testFiles: string[]) => {
-  const testResultsOut: string[] = [];
-  const testResultsErr: string[] = [];
-
   const failingTestFiles: string[] = [];
 
   return new Promise((resolve, reject) => {

--- a/src/java.ts
+++ b/src/java.ts
@@ -11,14 +11,14 @@ const compileCode = async (path: string) => {
     shell.exec(
       `${compileCommand} ${path}/*.${lang}`,
       (code, stdout, stderr) => {
-        if (stderr.length === 0) {
-          resolve({ succes: true, type: 'Compilation', message: stdout });
-        } else {
+        if (stderr.length !== 0) {
           reject({
-            succes: false,
-            type: 'Compilation',
-            message: { stdout, stderr },
+            success: false,
+            type: 'compilation',
+            message: stderr,
           });
+        } else {
+          resolve({ success: true, message: stdout });
         }
       },
     );
@@ -29,21 +29,23 @@ const testCode = async (path: string, testFiles: string[]) => {
   const testResultsOut: string[] = [];
   const testResultsErr: string[] = [];
 
+  const failingTestFiles: string[] = [];
+
   return new Promise((resolve, reject) => {
     shell.cd(path);
 
     const promises = [];
 
     testFiles.forEach((file, i) => {
-      const promise = new Promise((resolve2, reject2) => {
+      const promise = new Promise((resolveInner, rejectInner) => {
         shell.exec(`${testCommand} ${file}`, (code, stdout, stderr) => {
-          if (stdout.length !== 0) {
-            testResultsOut.push(stdout);
+          const lines = stdout.split('\n');
+          const statusLine = lines[lines.length - 3];
+
+          if (statusLine.substring(0, 2) !== 'OK' || stderr.length !== 0) {
+            failingTestFiles.push(file);
           }
-          if (stderr.length !== 0) {
-            testResultsErr.push(stderr);
-          }
-          resolve2();
+          resolveInner();
         });
       });
       promises.push(promise);
@@ -51,17 +53,24 @@ const testCode = async (path: string, testFiles: string[]) => {
 
     Promise.all(promises)
       .then(() => {
-        if (testResultsErr.length === 0) {
-          resolve({
-            success: true,
-            type: 'Test',
-            message: `${testResultsOut.length}/${testFiles.length} succeded`,
+        if (failingTestFiles.length !== 0) {
+          let message = `Error: ${failingTestFiles.length}/${
+            testFiles.length
+          } test files failed. \n The following tests failed:\n`;
+
+          failingTestFiles.forEach((file) => {
+            message += `${file}\n`;
+          });
+
+          reject({
+            success: false,
+            type: 'test',
+            message,
           });
         } else {
-          reject({
-            succes: false,
-            type: 'Test',
-            message: `${testResultsErr.length}/${testFiles.length} succeded`,
+          resolve({
+            success: true,
+            message: 'All test files succeeded!',
           });
         }
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,6 +145,14 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/rimraf@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-2.0.2.tgz#7f0fc3cf0ff0ad2a99bb723ae1764f30acaf8b6e"
+  integrity sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
+
 "@types/serve-static@*":
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
@@ -3015,7 +3023,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==


### PR DESCRIPTION
This PR fixes the parsing of the JUnit output. We can now determine if tests are failing, and if so which test files. I fixed so that the commit id directory in the tmp folder gets deleted after we are done.