### PR TITLE
Fix #63 A link to the build info

### DIFF
--- a/src/status.ts
+++ b/src/status.ts
@@ -61,6 +61,7 @@ const sendGithubStatus = (
       {
         state,
         description,
+        target_url: `http://localhost:3000/build/${commitId}`,
       },
       (err, data, headers) => {
         if (err) {


### PR DESCRIPTION
You can now click on "Details" at the commit to view the build details on our web 🔨 